### PR TITLE
Potential fix for code scanning alert no. 1: Time-of-check time-of-use filesystem race condition

### DIFF
--- a/src/tpad_hash.c
+++ b/src/tpad_hash.c
@@ -108,32 +108,37 @@ char *str2md5(const char *str) {
 
 char* tpad_hash_read_in_file(char* fp){
 
- if(access(fp, R_OK ) == -1) return("--\n'\0'");
- else {
-  FILE * pFile;
-  unsigned int lSize;
+ int fd = open(fp, O_RDONLY);
+ if (fd == -1) return("--\n'\0'");
 
-  size_t result;
-
-  pFile = fopen ( fp , "rb" );
-  if (pFile==NULL) return("--\n'\0'");
-
-  fseek (pFile , 0 , SEEK_END);
-  lSize = ftell (pFile);
-  rewind (pFile);
-
-  char* buffer = (char*) calloc (lSize+1, sizeof(char));
-   if (buffer == NULL) return("--\n'\0'");
-  //char  buffer[lSize+1];
-  result = fread (buffer,1,lSize,pFile);
-  if (result != lSize) {
-    free(buffer);
-    return("--\n'\0'");
-  }
-
-  fclose (pFile);
-  return (buffer);
+ FILE *pFile = fdopen(fd, "rb");
+ if (pFile == NULL) {
+   close(fd);
+   return("--\n'\0'");
  }
+
+ unsigned int lSize;
+ size_t result;
+
+ fseek(pFile, 0, SEEK_END);
+ lSize = ftell(pFile);
+ rewind(pFile);
+
+ char* buffer = (char*) calloc(lSize + 1, sizeof(char));
+ if (buffer == NULL) {
+   fclose(pFile);
+   return("--\n'\0'");
+ }
+
+ result = fread(buffer, 1, lSize, pFile);
+ if (result != lSize) {
+   free(buffer);
+   fclose(pFile);
+   return("--\n'\0'");
+ }
+
+ fclose(pFile);
+ return (buffer);
 }
 char *strFrombase64(const char *str) {
 	if(str == NULL) return("--\n'\0'");


### PR DESCRIPTION
Potential fix for [https://github.com/gnaservicesinc/tpad-project/security/code-scanning/1](https://github.com/gnaservicesinc/tpad-project/security/code-scanning/1)

To fix the TOCTOU race condition, we should avoid using `access` followed by `fopen`. Instead, we can directly open the file using `open` with appropriate flags and then use the resulting file descriptor to perform operations. This ensures that the file being checked and operated upon is the same. Specifically, we can replace `fopen` with `open` and use `fdopen` to convert the file descriptor into a `FILE*` if needed.

Changes to be made:
1. Replace the `access` and `fopen` calls with a single `open` call.
2. Use `fdopen` to convert the file descriptor to a `FILE*` for compatibility with the rest of the code.
3. Ensure proper error handling for the `open` and `fdopen` calls.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
